### PR TITLE
bug/export-typings

### DIFF
--- a/packages/antwerp-ui/react-components/package.json
+++ b/packages/antwerp-ui/react-components/package.json
@@ -7,7 +7,8 @@
   "exports": {
     ".": {
       "import": "./index.mjs",
-      "require": "./index.js"
+      "require": "./index.js",
+      "types": "./index.d.ts"
     }
   },
   "generators": "generators.json"


### PR DESCRIPTION
To be able to use React components in a Typescript file we need access to the typings

![typings-bug](https://github.com/a-ui/core_components_react/assets/14800045/5615ba14-b15e-4c49-852a-6a98eb443d10)



**Commits:**
- add index.d.ts to exported files in package.json