### PR TITLE
fixed a bug in hasValidFormat function of upload component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The `hasValidFormat` will now check for multiple type notations (MIME type, . notation). Users will no longer see wrong error states when they select valid file formats as stated in the `accept` prop of the html `input` field.
 - An `Alert` component without a title label will no longer add a margin pushing the description down.
 - A `Flyout` will not close anymore when clicking on a scrollbar inside of it.
 - Can use the `required` property for the `Autocomplete` component.

--- a/packages/antwerp-ui/react-components/src/utils/file.utils.ts
+++ b/packages/antwerp-ui/react-components/src/utils/file.utils.ts
@@ -1,13 +1,21 @@
 const MB = 1048576;
 
 export function hasValidFormat(file: File, acceptedFormat?: string): boolean {
-  return (
-    !acceptedFormat ||
-    acceptedFormat === '*' ||
-    acceptedFormat === file.type ||
-    (acceptedFormat?.includes('*') &&
-      !!acceptedFormat?.split('/')?.[0] &&
-      file.type.startsWith(acceptedFormat?.split('/')?.[0]))
+  if (!acceptedFormat) {
+    return false;
+  }
+
+  const acceptedFormats = acceptedFormat
+    .split(',')
+    .map((format) => format.trim())
+    .flatMap((format) => format.split('.'));
+
+  return acceptedFormats.some(
+    (format) =>
+      !format ||
+      format === '*' ||
+      format === file.type ||
+      (format.includes('*') && !!format.split('/')?.[0] && file.type.startsWith(format.split('/')?.[0]))
   );
 }
 


### PR DESCRIPTION
The `hasValidFormat` in the `Upload` component will now check for multiple type notations (MIME type, . notation). 
expected result: users won't see an error state in their selected file list while the format type is correct.

duplicate bug:
set acceptedFormat prop to : "image/*, application/pdf" or use the . notation : ".jpg, .pdf".
result: user will be able to select the designated file types but an error will be shown in the selected file list.

